### PR TITLE
feat(core): add global AppState contract

### DIFF
--- a/app/src/core/state.ts
+++ b/app/src/core/state.ts
@@ -1,0 +1,44 @@
+export type SkillType = 'JavaScript' | 'Testing' | 'Design' | 'Architecture';
+
+export type Route =
+  | { name: 'start' }
+  | { name: 'auth' }
+  | { name: 'dashboard' }
+  | { name: 'day'; day: number }
+  | { name: 'done' };
+
+export interface User {
+  id: string;
+  email: string;
+  name?: string; // optional for flexibility (can be shown on dashboard if present)
+}
+
+export interface GameState {
+  day: number;
+  health: number;
+  stress: number;
+  xp: number;
+  selectedSkills: SkillType[];
+  status: 'idle' | 'playing' | 'completed';
+}
+
+export interface AppState {
+  route: Route;
+  user: User | null;
+  game: GameState;
+}
+
+const defaultGameState: GameState = {
+  day: 1,
+  health: 100,
+  stress: 0,
+  xp: 0,
+  selectedSkills: [],
+  status: 'idle',
+};
+
+export const initialState: AppState = {
+  route: { name: 'start' },
+  user: null,
+  game: defaultGameState,
+};


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue
[https://github.com/OlgaMinaievaWebDev/rs-tandem-devquest/issues/30]
Closes #30

---

# 📌 Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Infrastructure
- [ ] Documentation
- [ ] Performance Improvement

---

# 📝 Description

This PR introduces the global application state contract in `app/src/core/state.ts`.

### What was added:
- `Route` type (start, auth, dashboard, day, done)
- `User` interface
- `SkillType` union
- `GameState` interface
- `AppState` interface
- `initialState` constant

### Why it was needed:
To establish a single source of truth for the application's state structure and define the contract used by Store, Router, Game Logic, and UI layers.

### Architectural decisions:
- Centralized state definition
- Strong typing for all state fields
- No form data stored globally at this stage (MVP decision)
- `name` in User is optional for future flexibility

---

# 🧠 Technical Details

### Files modified:
- `app/src/core/state.ts` (new file)

### New modules introduced:
- Global state contract definition

### Changes to state or event flow:
- No runtime logic changes
- Structure only

### Database changes:
- None

---

# 🧪 How to Test in progress

1. Checkout this branch.
2. Run: