### PR TITLE
feat(dashboard): implement sidebar with profile, status bars and acti…

### DIFF
--- a/app/src/styles/components/statusbar.scss
+++ b/app/src/styles/components/statusbar.scss
@@ -1,0 +1,56 @@
+@use '../abstracts/variables' as *;
+
+.status-bar {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  align-items: center;
+  gap: $space-3;
+
+  &__label {
+    font-size: $text-sm;
+    color: $color-text-secondary;
+  }
+
+  &__segments {
+    display: flex;
+    gap: 4px;
+  }
+
+  &__segment {
+    height: 10px;
+    flex: 1;
+    border-radius: $radius-pill;
+    background: $color-border;
+    box-shadow: 0 0 0 1px $color-border;
+    transition: background 120ms ease, box-shadow 120ms ease;
+
+    &.is-filled {
+      background: $color-text-muted;
+      box-shadow: 0 0 0 1px $color-text-muted;
+    }
+  }
+
+  &--authority {
+    .status-bar__segment.is-filled {
+      background: $color-highlight;
+      box-shadow: 0 0 0 1px $color-highlight;
+    }
+  }
+
+  &--stress {
+    .status-bar__segment.is-filled.is-low {
+      background: $color-success;
+      box-shadow: 0 0 0 1px $color-success;
+    }
+
+    .status-bar__segment.is-filled.is-mid {
+      background: $color-warning;
+      box-shadow: 0 0 0 1px $color-warning;
+    }
+
+    .status-bar__segment.is-filled.is-high {
+      background: $color-danger;
+      box-shadow: 0 0 0 1px $color-danger;
+    }
+  }
+}

--- a/app/src/styles/screens/dashboard/dashboardSideBar.scss
+++ b/app/src/styles/screens/dashboard/dashboardSideBar.scss
@@ -1,0 +1,144 @@
+@use '../../abstracts/variables' as *;
+
+.sidebar {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: $space-4;
+
+  // Profile block
+  &__profile {
+    display: grid;
+    grid-template-columns: 44px 1fr;
+    align-items: center;
+    gap: $space-3;
+
+    padding: $space-3;
+    border: 1px solid $color-border;
+    border-radius: $radius-md;
+    background: $color-surface-2;
+  }
+
+  &__avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: $radius-sm;
+    display: grid;
+    place-items: center;
+
+    border: 1px solid $color-border;
+    background: $color-surface;
+  }
+
+  &__username {
+    font-weight: $weight-bold;
+    color: $color-text;
+  }
+
+  // Status bars container
+  &__bars {
+    display: flex;
+    flex-direction: column;
+    gap: $space-3;
+  }
+
+  // Action menu
+  .action-menu {
+    display: flex;
+    flex-direction: column;
+    gap: $space-3;
+
+    &__item {
+      appearance: none;
+      font: inherit;
+
+      width: 100%;
+      display: grid;
+      grid-template-columns: 28px 1fr auto;
+      align-items: center;
+      gap: $space-3;
+
+      padding: $space-3;
+      border-radius: $radius-md;
+      border: 1px solid $color-border;
+
+      background: $color-surface-2;
+      color: $color-text;
+      cursor: pointer;
+      text-align: left;
+
+      transition:
+        border-color 120ms ease,
+        box-shadow 120ms ease,
+        transform 120ms ease;
+
+      &:hover {
+        border-color: $color-success;
+        box-shadow: 0 0 10px rgba($color-success, 0.25);
+        transform: translateY(-1px);
+      }
+
+      &:focus-visible {
+        outline: 2px solid $color-success;
+        outline-offset: 2px;
+      }
+    }
+
+    &__icon {
+      font-size: $text-md;
+    }
+
+    &__label {
+      font-size: $text-sm;
+      color: $color-text;
+    }
+
+    &__badge {
+      font-size: $text-xs;
+      padding: 2px 8px;
+      border-radius: $radius-pill;
+      border: 1px solid $color-border;
+
+      color: $color-text-muted;
+      background: $color-surface;
+    }
+  }
+
+  // Bottom controls
+  &__controls {
+    margin-top: auto;
+    display: flex;
+    flex-direction: column;
+    gap: $space-3;
+  }
+
+  &__button {
+    appearance: none;
+    font: inherit;
+
+    border: 1px solid $color-border;
+    background: $color-surface-2;
+    color: $color-text;
+
+    padding: $space-3;
+    border-radius: $radius-md;
+
+    cursor: pointer;
+
+    transition:
+      border-color 120ms ease,
+      box-shadow 120ms ease,
+      transform 120ms ease;
+
+    &:hover {
+      border-color: $color-success;
+      box-shadow: 0 0 10px rgba($color-success, 0.25);
+      transform: translateY(-1px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid $color-success;
+      outline-offset: 2px;
+    }
+  }
+}

--- a/app/src/ui/components/statusBar.ts
+++ b/app/src/ui/components/statusBar.ts
@@ -1,0 +1,51 @@
+import '../../styles/components/statusBar.scss';
+
+export type StatusBarVariant = 'stress' | 'authority';
+
+export function renderStatusBar(
+  label: string,
+  value: number,
+  max: number,
+  variant: StatusBarVariant,
+): HTMLElement {
+  const root = document.createElement('div');
+  root.className = `status-bar status-bar--${variant}`;
+
+  const clampedMax = Math.max(1, max);
+  const clampedValue = Math.max(0, Math.min(value, clampedMax));
+
+  const labelEl = document.createElement('div');
+  labelEl.className = 'status-bar__label';
+  labelEl.textContent = label;
+
+  const segmentsEl = document.createElement('div');
+  segmentsEl.className = 'status-bar__segments';
+
+  // Choose how many segments to render.
+  // If max is small (<= 12) render max segments; otherwise render 10 segments.
+  const segmentCount = clampedMax <= 12 ? clampedMax : 10;
+  const filledCount = Math.round((clampedValue / clampedMax) * segmentCount);
+
+  // Stress color step based on ratio (green -> orange -> red)
+  const ratio = clampedValue / clampedMax;
+  let stressTone: 'low' | 'mid' | 'high' = 'low';
+  if (ratio >= 0.67) stressTone = 'high';
+  else if (ratio >= 0.34) stressTone = 'mid';
+
+  for (let i = 0; i < segmentCount; i += 1) {
+    const seg = document.createElement('span');
+    seg.className = 'status-bar__segment';
+
+    const isFilled = i < filledCount;
+    if (isFilled) seg.classList.add('is-filled');
+
+    if (variant === 'stress' && isFilled) {
+      seg.classList.add(`is-${stressTone}`); // is-low / is-mid / is-high
+    }
+
+    segmentsEl.append(seg);
+  }
+
+  root.append(labelEl, segmentsEl);
+  return root;
+}

--- a/app/src/ui/screens/dashboard/dashboardScreen.ts
+++ b/app/src/ui/screens/dashboard/dashboardScreen.ts
@@ -1,5 +1,6 @@
 import { createDashboardLayout } from '../../layouts/dashboardLayout';
 import { createDashboardHeader } from './dashboardHeader';
+import createSidebar from './dashboardSideBar';
 import '../../../styles/screens/dashboard/dashboardScreen.scss';
 
 export default function renderDashboardScreen(): HTMLElement {
@@ -9,10 +10,7 @@ export default function renderDashboardScreen(): HTMLElement {
   layout.header.replaceChildren(createDashboardHeader({ day: 1 }));
 
   // temp sidebar
-  const s = document.createElement('nav');
-  s.textContent = 'Menu (later)';
-  layout.sidebar.textContent = '';
-  layout.sidebar.append(s);
+  layout.sidebar.replaceChildren(createSidebar());
 
   // temp main
   const m = document.createElement('section');

--- a/app/src/ui/screens/dashboard/dashboardSideBar.ts
+++ b/app/src/ui/screens/dashboard/dashboardSideBar.ts
@@ -1,0 +1,110 @@
+import { renderStatusBar } from '../../components/statusBar';
+import '../../../styles/screens/dashboard/dashboardSideBar.scss';
+
+export type SidebarHandlers = {
+  onCoffeeBreak?: () => void;
+  onSmokeBreak?: () => void;
+  onLunchBreak?: () => void;
+  onHelp?: () => void;
+  onRestart?: () => void;
+  onLogout?: () => void;
+};
+
+type MenuItemConfig = {
+  icon: string;
+  label: string;
+  badge?: number;
+  onClick?: () => void;
+};
+
+function createActionMenuItem({ icon, label, badge, onClick }: MenuItemConfig): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'action-menu__item';
+
+  const iconEl = document.createElement('span');
+  iconEl.className = 'action-menu__icon';
+  iconEl.textContent = icon;
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'action-menu__label';
+  labelEl.textContent = label;
+
+  btn.append(iconEl, labelEl);
+
+  if (typeof badge === 'number') {
+    const badgeEl = document.createElement('span');
+    badgeEl.className = 'action-menu__badge';
+    badgeEl.textContent = String(badge);
+    btn.append(badgeEl);
+  }
+
+  btn.addEventListener('click', onClick ?? (() => {}));
+  return btn;
+}
+
+export default function createSidebar(handlers: SidebarHandlers = {}): HTMLElement {
+  const root = document.createElement('div');
+  root.className = 'sidebar';
+
+  // ---- Profile (TEMP) ----
+  const profile = document.createElement('div');
+  profile.className = 'sidebar__profile';
+
+  const avatar = document.createElement('div');
+  avatar.className = 'sidebar__avatar';
+  avatar.textContent = '👾';
+
+  const username = document.createElement('div');
+  username.className = 'sidebar__username';
+  username.textContent = 'Player';
+
+  profile.append(avatar, username);
+
+  // ---- Status Bars (TEMP) ----
+  const stress = 50;
+  const stressMax = 100;
+
+  const authority = 3;
+  const authorityMax = 10;
+
+  const bars = document.createElement('div');
+  bars.className = 'sidebar__bars';
+  bars.append(
+    renderStatusBar('Stress', stress, stressMax, 'stress'),
+    renderStatusBar('Authority', authority, authorityMax, 'authority'),
+  );
+
+  // ---- Action Menu ----
+  const menu = document.createElement('div');
+  menu.className = 'action-menu';
+
+  menu.append(
+    createActionMenuItem({
+      icon: '☕',
+      label: 'Coffee Break',
+      badge: undefined, // later from store
+      onClick: handlers.onCoffeeBreak,
+    }),
+    createActionMenuItem({
+      icon: '🚬',
+      label: 'Smoke Break',
+      badge: undefined,
+      onClick: handlers.onSmokeBreak,
+    }),
+    createActionMenuItem({
+      icon: '🍱',
+      label: 'Lunch Break',
+      badge: undefined,
+      onClick: handlers.onLunchBreak,
+    }),
+    createActionMenuItem({
+      icon: '❓',
+      label: 'Help',
+      onClick: handlers.onHelp,
+    }),
+  );
+
+  root.append(profile, bars, menu);
+  return root;
+}


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #44 

[(Always link the issue this PR resolves)](https://github.com/OlgaMinaievaWebDev/rs-tandem-devquest/issues/44)

---

# 📌 Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Infrastructure
- [ ] Documentation
- [ ] Performance Improvement

---

# 📝 Description

This PR implements the **Dashboard Sidebar (Player HUD)** for the DevQuest application.

The sidebar is a persistent UI element displayed during gameplay and provides key information about the player state as well as quick action controls.

### What was added

**Profile Block**
- Avatar placeholder
- Username display

**Reusable StatusBar Component**
- Supports two variants:
  - `stress`
  - `authority`
- Segmented progress bars
- Stress color levels:
  - Green (low)
  - Orange (medium)
  - Red (high)

**Action Menu**
- Coffee Break
- Smoke Break
- Lunch Break
- Help

Each menu item includes:
- Icon
- Label
- Optional badge support
- Click handlers

### Why it was needed

The sidebar acts as the **player HUD** and will display the current state of the player during the game.  
It is designed to later connect with the centralized store so that player stats update dynamically.

### Architectural notes

- Sidebar built as a reusable UI component
- StatusBar extracted as a separate reusable component
- Styling follows **BEM structure**

---

# 🧠 Technical Details

### Files added
