### PR TITLE
feat:add dayMain with 7 days cards, add dayScreen with options to cho…

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -2,6 +2,7 @@ import Router from './router/router';
 import type { Route } from './core/state';
 import { renderStartScreen } from './ui/screens/startScreen';
 import renderDashboardScreen from './ui/screens/dashboard/dashboardScreen';
+import renderDayScreen from './ui/screens/day/dayScreen';
 import './styles/main.scss';
 
 const root = document.querySelector<HTMLDivElement>('#app');
@@ -20,7 +21,20 @@ const render = (route: Route) => {
       break;
 
     case 'dashboard':
-      root.replaceChildren(renderDashboardScreen());
+      root.replaceChildren(
+        renderDashboardScreen({
+          onSelectDay: (day: number) => router.navigate({ name: 'day', day }),
+        }),
+      );
+      break;
+
+    case 'day':
+      root.replaceChildren(
+        renderDayScreen({
+          day: route.day,
+          onBackToDashboard: () => router.navigate({ name: 'dashboard' }),
+        }),
+      );
       break;
 
     default:

--- a/app/src/styles/screens/dashboard/dashboardMain.scss
+++ b/app/src/styles/screens/dashboard/dashboardMain.scss
@@ -1,0 +1,57 @@
+@use '../../abstracts/variables' as *;
+
+.dashboard-main {
+  display: flex;
+  flex-direction: column;
+  gap: $space-5;
+
+  &__title {
+    margin: 0;
+    font-size: $text-xl;
+    font-weight: $weight-bold;
+    color: $color-text;
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: $space-4;
+  }
+
+  &__card {
+    border: 1px solid $color-border;
+    background: $color-surface;
+    border-radius: $radius-md;
+
+    padding: $space-4;
+    cursor: pointer;
+
+    display: flex;
+    flex-direction: column;
+    gap: $space-2;
+
+    transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+
+    &:hover:not(.is-locked) {
+      border-color: $color-success;
+      box-shadow: 0 0 10px rgba($color-success, 0.25);
+      transform: translateY(-2px);
+    }
+
+    &.is-locked {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  &__day {
+    font-size: $text-lg;
+    font-weight: $weight-bold;
+    color: $color-text;
+  }
+
+  &__status {
+    font-size: $text-sm;
+    color: $color-text-muted;
+  }
+}

--- a/app/src/styles/screens/day/dayMain.scss
+++ b/app/src/styles/screens/day/dayMain.scss
@@ -1,0 +1,94 @@
+@use '../../abstracts/variables' as *;
+.day-main__title {
+  margin: 0;
+  font-size: $text-lg;
+  font-weight: $weight-bold;
+  color: $color-text;
+}
+
+.day-main__games {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $space-3;
+
+  @media (min-width: 720px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.day-main__game {
+  appearance: none;
+  font: inherit;
+
+  text-align: left;
+  cursor: pointer;
+
+  border: 1px solid $color-border;
+  border-radius: $radius-md;
+  background: $color-surface-2;
+  color: $color-text;
+
+  padding: $space-4;
+
+  transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+
+  &:hover {
+    border-color: $color-success;
+    box-shadow: 0 0 10px rgba($color-success, 0.25);
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-success;
+    outline-offset: 2px;
+  }
+}
+
+.day-main__game-title {
+  font-weight: $weight-bold;
+  font-size: $text-md;
+  color: $color-text;
+}
+
+.day-main__game-subtitle {
+  margin-top: $space-2;
+  font-size: $text-sm;
+  color: $color-text-muted;
+}
+
+.day-main__footer {
+  margin-top: $space-4;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.day-main__btn {
+  appearance: none;
+  font: inherit;
+
+  border: 1px solid $color-border;
+  background: $color-surface-2;
+  color: $color-text;
+
+  padding: $space-3 $space-4;
+  border-radius: $radius-md;
+
+  cursor: pointer;
+
+  transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+
+  &:hover {
+    border-color: $color-success;
+    box-shadow: 0 0 10px rgba($color-success, 0.25);
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-success;
+    outline-offset: 2px;
+  }
+}

--- a/app/src/styles/screens/day/dayScreen.scss
+++ b/app/src/styles/screens/day/dayScreen.scss
@@ -1,0 +1,11 @@
+@use '../../abstracts/variables' as *;
+
+.day-screen {
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+
+  gap: $space-5;
+}

--- a/app/src/ui/components/button.ts
+++ b/app/src/ui/components/button.ts
@@ -31,7 +31,7 @@ export function createButton({
   // 3. Content Construction (Safe for icons)
   if (icon) {
     const iconSpan = document.createElement('span');
-    iconSpan.className = 'bt__icon';
+    iconSpan.className = 'btn__icon';
     iconSpan.textContent = icon;
     button.appendChild(iconSpan);
   }

--- a/app/src/ui/screens/dashboard/dashboardMain.ts
+++ b/app/src/ui/screens/dashboard/dashboardMain.ts
@@ -1,0 +1,53 @@
+import '../../../styles/screens/dashboard/dashboardMain.scss';
+
+export type DashboardMainProps = {
+  totalDays?: number;
+  currentDay?: number; // used for lock/unlock UI
+  onSelectDay?: (day: number) => void;
+};
+
+export function createDashboardMain({
+  totalDays = 7,
+  currentDay = 1,
+  onSelectDay,
+}: DashboardMainProps = {}): HTMLElement {
+  const root = document.createElement('section');
+  root.className = 'dashboard-main';
+
+  const title = document.createElement('h2');
+  title.className = 'dashboard-main__title';
+  title.textContent = 'Your Week';
+
+  const list = document.createElement('div');
+  list.className = 'dashboard-main__grid';
+
+  for (let day = 1; day <= totalDays; day += 1) {
+    const card = document.createElement('button');
+    card.type = 'button';
+    card.className = 'dashboard-main__card';
+
+    const locked = day > currentDay;
+    if (locked) card.classList.add('is-locked');
+
+    card.disabled = locked;
+
+    const label = document.createElement('div');
+    label.className = 'dashboard-main__day';
+    label.textContent = `Day ${day}`;
+
+    const status = document.createElement('div');
+    status.className = 'dashboard-main__status';
+    status.textContent = locked ? 'Locked' : 'Start';
+
+    card.append(label, status);
+
+    card.addEventListener('click', () => {
+      onSelectDay?.(day);
+    });
+
+    list.append(card);
+  }
+
+  root.append(title, list);
+  return root;
+}

--- a/app/src/ui/screens/dashboard/dashboardScreen.ts
+++ b/app/src/ui/screens/dashboard/dashboardScreen.ts
@@ -1,21 +1,27 @@
 import { createDashboardLayout } from '../../layouts/dashboardLayout';
 import { createDashboardHeader } from './dashboardHeader';
 import createSidebar from './dashboardSideBar';
+import { createDashboardMain } from './dashboardMain';
 import '../../../styles/screens/dashboard/dashboardScreen.scss';
 
-export default function renderDashboardScreen(): HTMLElement {
+export type DashboardScreenProps = {
+  onSelectDay: (day: number) => void;
+};
+
+export default function renderDashboardScreen({ onSelectDay }: DashboardScreenProps): HTMLElement {
   const layout = createDashboardLayout();
 
-  // header
   layout.header.replaceChildren(createDashboardHeader({ day: 1 }));
 
-  // temp sidebar
   layout.sidebar.replaceChildren(createSidebar());
 
-  // temp main
-  const m = document.createElement('section');
-  m.textContent = 'Games / Days list (later)';
-  layout.main.append(m);
+  layout.main.replaceChildren(
+    createDashboardMain({
+      onSelectDay,
+      currentDay: 1,
+      totalDays: 7,
+    }),
+  );
 
   return layout.root;
 }

--- a/app/src/ui/screens/day/dayMain.ts
+++ b/app/src/ui/screens/day/dayMain.ts
@@ -1,0 +1,103 @@
+import { createButton } from '../../components/button';
+import '../../../styles/screens/day/dayMain.scss';
+
+export type DayGameId = 'bugfix' | 'quiz' | 'debug';
+
+export type DayMainProps = {
+  day: number;
+  briefing?: string;
+  aiMessage?: string;
+  onStartGame?: (gameId: DayGameId) => void;
+  onBackToDashboard?: () => void;
+};
+
+type GameButtonConfig = {
+  id: DayGameId;
+  title: string;
+  subtitle: string;
+};
+
+const DEFAULT_GAMES: GameButtonConfig[] = [
+  { id: 'bugfix', title: 'Fix the Bug', subtitle: 'Find and patch a small issue' },
+  { id: 'quiz', title: 'JS Quiz', subtitle: 'Answer 5 quick questions' },
+  { id: 'debug', title: 'Debug Challenge', subtitle: 'Trace logs and spot the error' },
+];
+
+export function createDayMain({
+  day,
+  briefing = 'Your team lead assigned you a task. Pick an approach and complete it.',
+  aiMessage = 'AI Lead: Welcome to today’s task. Do it by the book.',
+  onStartGame,
+  onBackToDashboard,
+}: DayMainProps): HTMLElement {
+  const root = document.createElement('section');
+  root.className = 'day-main';
+
+  const dialogue = document.createElement('div');
+  dialogue.className = 'day-main__dialogue';
+
+  const lead = document.createElement('div');
+  lead.className = 'day-main__line';
+  lead.textContent = aiMessage;
+
+  dialogue.append(lead);
+
+  const card = document.createElement('div');
+  card.className = 'day-main__card';
+
+  const title = document.createElement('h2');
+  title.className = 'day-main__title';
+  title.textContent = 'Today’s mission';
+
+  const text = document.createElement('p');
+  text.className = 'day-main__text';
+  text.textContent = briefing;
+
+  const games = document.createElement('div');
+  games.className = 'day-main__games';
+
+  for (let i = 0; i < DEFAULT_GAMES.length; i += 1) {
+    const game = DEFAULT_GAMES[i];
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'day-main__game';
+    btn.setAttribute('aria-label', `${game.title}: ${game.subtitle}`);
+
+    const btnTitle = document.createElement('div');
+    btnTitle.className = 'day-main__game-title';
+    btnTitle.textContent = game.title;
+
+    const btnSub = document.createElement('div');
+    btnSub.className = 'day-main__game-subtitle';
+    btnSub.textContent = game.subtitle;
+
+    btn.append(btnTitle, btnSub);
+
+    btn.addEventListener('click', () => {
+      onStartGame?.(game.id);
+    });
+
+    games.append(btn);
+  }
+
+  const footer = document.createElement('div');
+  footer.className = 'day-main__footer';
+
+  const back = createButton({
+    label: 'Back to Dashboard',
+    icon: '←',
+    variant: 'terminal',
+    className: 'day-main__btn',
+    onClick: () => {
+      onBackToDashboard?.();
+    },
+    ariaLabel: 'Back to dashboard',
+  });
+
+  footer.append(back);
+  card.append(title, text, games, footer);
+  root.append(dialogue, card);
+
+  return root;
+}

--- a/app/src/ui/screens/day/dayScreen.ts
+++ b/app/src/ui/screens/day/dayScreen.ts
@@ -1,0 +1,36 @@
+import { createDashboardLayout } from '../../layouts/dashboardLayout';
+import { createDashboardHeader } from '../dashboard/dashboardHeader';
+import createSidebar from '../dashboard/dashboardSideBar';
+import { createDayMain } from './dayMain';
+
+import '../../../styles/screens/day/dayScreen.scss';
+
+export type DayScreenProps = {
+  day: number;
+  onBackToDashboard: () => void;
+};
+
+export default function renderDayScreen({ day, onBackToDashboard }: DayScreenProps): HTMLElement {
+  const layout = createDashboardLayout();
+
+  layout.header.replaceChildren(createDashboardHeader({ day, totalDays: 7, title: 'DevQuest' }));
+
+  layout.sidebar.replaceChildren(
+    createSidebar({
+      onHelp: () => console.log('help'),
+      onCoffeeBreak: () => console.log('coffee'),
+      onLunchBreak: () => console.log('lunch'),
+      onSmokeBreak: () => console.log('smoke'),
+    }),
+  );
+
+  layout.main.replaceChildren(
+    createDayMain({
+      day,
+      onStartGame: (gameId) => console.log('start', gameId),
+      onBackToDashboard,
+    }),
+  );
+
+  return layout.root;
+}


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #  28
[https://github.com/OlgaMinaievaWebDev/rs-tandem-devquest/issues/28]

---

# 📌 Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Infrastructure
- [ ] Documentation
- [ ] Performance Improvement

---

# 📝 Description

This PR implements the **Day Screen UI and game selection flow** for DevQuest.

The screen allows the player to:

- View the **AI briefing for the current day**
- Choose between **three mini-games**
- Return back to the **Dashboard**

The implementation reuses the existing **DashboardLayout**, so the Day screen keeps the same **Header + Sidebar + Main** structure used across the app.

Navigation between screens is now handled through the router and route parameters.

---

# 🧠 Technical Details

### New UI Components

**Day Screen**
- `ui/screens/day/dayScreen.ts`
- `ui/screens/day/dayMain.ts`

**Styles**
- `styles/screens/day/dayScreen.scss`
- `styles/screens/day/dayMain.scss`

### Features Implemented

**DayMain UI**
- AI message / briefing section
- Game selection UI with 3 mini-game buttons:
  - Fix the Bug
  - JS Quiz
  - Debug Challenge
- Back to Dashboard button

### Reusable Components Used

- `createDashboardLayout`
- `createDashboardHeader`
- `createSidebar`
- `createButton` (for the Back button)

### Routing

Day screen now uses the route parameter:
# Pull Request

## 🔗 Related Issue

Closes #  
(Replace with the issue number once linked)

---

# 📌 Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Infrastructure
- [ ] Documentation
- [ ] Performance Improvement

---

# 📝 Description

This PR implements the **Day Screen UI and game selection flow** for DevQuest.

The screen allows the player to:

- View the **AI briefing for the current day**
- Choose between **three mini-games**
- Return back to the **Dashboard**

The implementation reuses the existing **DashboardLayout**, so the Day screen keeps the same **Header + Sidebar + Main** structure used across the app.

Navigation between screens is now handled through the router and route parameters.

---

# 🧠 Technical Details

### New UI Components

**Day Screen**
- `ui/screens/day/dayScreen.ts`
- `ui/screens/day/dayMain.ts`

**Styles**
- `styles/screens/day/dayScreen.scss`
- `styles/screens/day/dayMain.scss`

### Features Implemented

**DayMain UI**
- AI message / briefing section
- Game selection UI with 3 mini-game buttons:
  - Fix the Bug
  - JS Quiz
  - Debug Challenge
- Back to Dashboard button

### Reusable Components Used

- `createDashboardLayout`
- `createDashboardHeader`
- `createSidebar`
- `createButton` (for the Back button)

### Routing

Day screen now uses the route parameter:

The **Back to Dashboard** button returns the user to the dashboard.

### Event Flow

Callbacks used for interaction:

Game logic will be connected in future PRs.

---

# 🧪 How to Test

1. Run the project locally
2. Navigate to the Dashboard screen
3. Select a day (for example Day 1)
4. Verify the Day screen loads with:
   - AI briefing
   - Game selection buttons
   - Back to Dashboard button
5. Click **Back to Dashboard**

Expected result:

- Day screen renders correctly
- Game buttons trigger callbacks
- Back button returns to dashboard

---

# 📷 Screenshots (if UI related)

Day Screen UI includes:

- AI message / briefing
- Game selection cards
- Back to Dashboard button
- Sidebar HUD (stress / authority)

(Screenshots can be attached to the PR)

---

# ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (explain below)

---

# 🛡 Security Considerations

- [x] No sensitive data exposed
- [x] No API keys leaked
- [x] No external integrations introduced
- [x] Input validated where required

---

# 📋 Checklist

- [x] Code compiles
- [x] Lint passes
- [x] TypeScript passes
- [x] No console errors
- [x] Follows project structure
- [ ] Linked to correct Issue
- [x] Tested manually

---

# 🚀 Impact

- [x] UI
- [ ] Game Logic
- [ ] Store
- [ ] Supabase
- [ ] AI Integration
- [ ] Deployment

---

# 📦 Deployment Notes

No special deployment steps required.

---

# 👀 Review Focus

Please review:

- Day screen architecture
- Routing integration with `/day/:day`
- Component separation (`dayScreen` vs `dayMain`)
- Use of reusable components (`createButton`)
- UI consistency with the existing Dashboard layout