### PR TITLE
Fix/64 auth route guards

### DIFF
--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -22,6 +22,7 @@ module.exports = {
 
     // Standard
     'no-console': ['warn', { allow: ['warn', 'error'] }],
+    'no-param-reassign': ['error', { props: false }],
   },
   ignorePatterns: ['dist', 'node_modules'],
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -8,10 +8,14 @@ import renderDashboardScreen from './ui/screens/dashboard/dashboardScreen';
 import renderDayScreen from './ui/screens/day/dayScreen';
 import renderNotFoundScreen from './ui/screens/notFoundScreen';
 import { getSession, onAuthStateChange, signIn, signUp, signOut } from './services/auth';
+import { Loader } from './ui/components/loader';
 import './styles/main.scss';
 
 const root = document.querySelector<HTMLDivElement>('#app');
 if (!root) throw new Error('#app not found');
+
+const spinner = new Loader();
+document.body.appendChild(spinner.getElement());
 
 let router: Router;
 
@@ -27,9 +31,9 @@ const watchAuth = () => {
         store.setState({
           user: {
             id: session.user.id,
-            email: session.user['user_metadata'].email || session.user.email || '',
-            name: session.user['user_metadata']?.name,
-            avatarId: session.user['user_metadata']?.avatar,
+            email: session.user.user_metadata.email || session.user.email || '',
+            name: session.user.user_metadata?.name,
+            avatarId: session.user.user_metadata?.avatar,
           },
         });
 
@@ -50,28 +54,37 @@ const handlers = {
 
   onSignIn: async (email: string, pass: string) => {
     try {
+      spinner.show('Logging in...');
       await signIn(email, pass);
     } catch (error) {
       console.error(error);
       alert(error instanceof Error ? error.message : 'Login failed');
+    } finally {
+      spinner.hide();
     }
   },
 
   onSignUp: async (name: string, email: string, pass: string, avatar: string) => {
     try {
+      spinner.show('Creating account...');
       await signUp(email, pass, name, avatar);
     } catch (error) {
       console.error(error);
       alert(error instanceof Error ? error.message : 'Sign up failed');
+    } finally {
+      spinner.hide();
     }
   },
 
   onSignOut: async () => {
     try {
+      spinner.show('Logging out...');
       await signOut();
     } catch (error) {
       console.error(error);
       alert(error instanceof Error ? error.message : 'Sign out failed');
+    } finally {
+      spinner.hide();
     }
   },
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -8,7 +8,7 @@ import renderDashboardScreen from './ui/screens/dashboard/dashboardScreen';
 import renderDayScreen from './ui/screens/day/dayScreen';
 import renderNotFoundScreen from './ui/screens/notFoundScreen';
 import { getSession, onAuthStateChange, signIn, signUp, signOut } from './services/auth';
-import { Loader } from './ui/components/loader';
+import Loader from './ui/components/loader';
 import './styles/main.scss';
 
 const root = document.querySelector<HTMLDivElement>('#app');

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -15,40 +15,36 @@ if (!root) throw new Error('#app not found');
 
 let router: Router;
 
-const initAuth = async () => {
-  const session = await getSession();
-
-  if (session?.user) {
-    router.navigate({ name: 'dashboard' });
-  }
-};
-
 const watchAuth = () => {
-  onAuthStateChange(() => {
-    getSession()
-      .then((session) => {
-        if (session?.user) {
-          store.setState({
-            user: {
-              id: session.user.id,
-              email: session.user['user_metadata'].email || '',
-              name: session.user['user_metadata']?.name,
-              avatarId: session.user['user_metadata']?.avatar,
-            },
-          });
-          router.navigate({ name: 'dashboard' });
-          return;
-        }
+  onAuthStateChange((event, session) => {
+    if (
+      event === 'INITIAL_SESSION' ||
+      event === 'SIGNED_IN' ||
+      event === 'TOKEN_REFRESHED' ||
+      event === 'USER_UPDATED'
+    ) {
+      if (session?.user) {
+        store.setState({
+          user: {
+            id: session.user.id,
+            email: session.user['user_metadata'].email || session.user.email || '',
+            name: session.user['user_metadata']?.name,
+            avatarId: session.user['user_metadata']?.avatar,
+          },
+        });
 
-        router.navigate({ name: 'auth' });
-      })
-      .catch((error) => {
-        console.error(error);
-      });
+        const currentRoute = store.getState().route.name;
+        if (currentRoute === 'auth') {
+          router.navigate({ name: 'dashboard' });
+        }
+      }
+    } else if (event === 'SIGNED_OUT') {
+      store.setState({ user: null });
+      router.navigate({ name: 'auth' });
+    }
   });
 };
 
-// --- WIRE HANDLERS ---
 const handlers = {
   onStart: () => router.navigate({ name: 'auth' }),
 
@@ -131,22 +127,29 @@ const renderApp = (state: AppState) => {
   }
 };
 
-// --- INITIALIZE ROUTER & STORE ---
-const handleRouterChange = (route: Route) => {
+const handleRouterChange = async (route: Route) => {
+  const session = await getSession();
+  const isLogged = !!session?.user;
+  const publicRoutes = ['start', 'auth'];
+
+  if (!isLogged && !publicRoutes.includes(route.name)) {
+    router.navigate({ name: 'auth' });
+    return;
+  }
+
+  if (isLogged && route.name === 'auth') {
+    router.navigate({ name: 'dashboard' });
+    return;
+  }
+
   store.setState({ route });
 };
 
 router = new Router(handleRouterChange);
 
-// --- SUBSCRIBE TO STORE ---
 store.subscribe((state) => {
   renderApp(state);
 });
 
 router.init();
-
-initAuth().catch((error) => {
-  console.error(error);
-});
-
 watchAuth();

--- a/app/src/services/auth.ts
+++ b/app/src/services/auth.ts
@@ -1,6 +1,5 @@
 import supabase from '../lib/supabase';
 
-// sign up
 export async function signUp(email: string, password: string, name: string, avatar: string) {
   const { data, error } = await supabase.auth.signUp({
     email,
@@ -18,7 +17,6 @@ export async function signUp(email: string, password: string, name: string, avat
   return data;
 }
 
-// sign in
 export async function signIn(email: string, password: string) {
   const { data, error } = await supabase.auth.signInWithPassword({
     email,
@@ -30,7 +28,6 @@ export async function signIn(email: string, password: string) {
   return data;
 }
 
-// get session check if logged in
 export async function getSession() {
   const { data, error } = await supabase.auth.getSession();
 
@@ -39,22 +36,18 @@ export async function getSession() {
   return data.session;
 }
 
-// sign out
 export async function signOut() {
   const { error } = await supabase.auth.signOut();
 
   if (error) throw error;
 }
 
-// react on any change if login, logout, session changes
-export function onAuthStateChange(callback: () => void) {
+export function onAuthStateChange(callback: (event: string, session: any) => void) {
   const {
     data: { subscription },
-  } = supabase.auth.onAuthStateChange(() => {
-    callback();
+  } = supabase.auth.onAuthStateChange((event, session) => {
+    callback(event, session);
   });
 
-  return () => {
-    subscription.unsubscribe();
-  };
+  return subscription;
 }

--- a/app/src/ui/components/loader.ts
+++ b/app/src/ui/components/loader.ts
@@ -1,8 +1,10 @@
 import '../../styles/components/loader.scss';
 
-export class Loader {
+export default class Loader {
   private element: HTMLElement;
+
   private messageElement: HTMLElement;
+
   constructor() {
     this.element = document.createElement('div');
     this.element.classList.add('loader__container', 'loader__container--hidden');

--- a/app/src/ui/screens/authScreen.ts
+++ b/app/src/ui/screens/authScreen.ts
@@ -1,6 +1,5 @@
 import { createButton } from '../components/button';
 import '../../styles/screens/authScreen.scss';
-import { Loader } from '../components/loader';
 import { debounce } from '../../utils/debounce';
 import {
   validateEmail,
@@ -65,11 +64,9 @@ export function renderAuthScreen(handlers: AuthScreenHandlers): HTMLElement {
   const screen = document.createElement('section');
   screen.className = 'auth-screen';
 
-  let spinner = new Loader();
-
   const card = document.createElement('div');
   card.className = 'auth-screen__card';
-  screen.append(card, spinner.getElement());
+  screen.append(card);
 
   // Login <-> Sign Up
   function renderCardContent() {
@@ -132,7 +129,6 @@ export function renderAuthScreen(handlers: AuthScreenHandlers): HTMLElement {
       if (isLoading) return;
 
       isLoading = true;
-      spinner.show();
       submitBtn.disabled = true;
 
       const formData = new FormData(form);
@@ -148,7 +144,6 @@ export function renderAuthScreen(handlers: AuthScreenHandlers): HTMLElement {
         }
       } finally {
         isLoading = false;
-        spinner.hide();
         runValidation();
       }
     });

--- a/app/src/ui/screens/authScreen.ts
+++ b/app/src/ui/screens/authScreen.ts
@@ -1,6 +1,6 @@
 import { createButton } from '../components/button';
 import '../../styles/screens/authScreen.scss';
-import { debounce } from '../../utils/debounce';
+import debounce from '../../utils/debounce';
 import {
   validateEmail,
   validatePassword,
@@ -54,6 +54,127 @@ function createInputGroup(
 
   group.append(label, groupInp);
   return { group, input, errorSpan };
+}
+
+function renderAvatarPicker(
+  avatars: string[],
+  selectedAvatar: string,
+  onSelect: (avatar: string) => void,
+): HTMLFieldSetElement {
+  const avatarPicker = document.createElement('fieldset');
+  avatarPicker.className = 'auth-screen__avatar-picker';
+
+  const legend = document.createElement('legend');
+  legend.className = 'auth-screen__avatar-title';
+  legend.textContent = 'Choose your avatar:';
+  avatarPicker.appendChild(legend);
+
+  const avatarlist = document.createElement('div');
+  avatarlist.className = 'auth-screen__avatar-list';
+
+  const avatarButtons: HTMLButtonElement[] = [];
+
+  avatars.forEach((src) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = `auth-screen__avatar-btn ${selectedAvatar === src ? 'is-selected' : ''}`;
+
+    const img = document.createElement('img');
+    img.src = src;
+    img.alt = 'Avatar';
+    img.className = 'auth-screen__avatar-img';
+
+    btn.appendChild(img);
+    btn.addEventListener('click', () => {
+      onSelect(src);
+      avatarButtons.forEach((b) => b.classList.remove('is-selected'));
+      btn.classList.add('is-selected');
+    });
+
+    avatarButtons.push(btn);
+    avatarlist.appendChild(btn);
+  });
+  avatarPicker.appendChild(avatarlist);
+  return avatarPicker;
+}
+
+function applyValidation(
+  { group, input, errorSpan }: ReturnType<typeof createInputGroup>,
+  check: ValidationResult,
+) {
+  const isTouched = input.dataset.touched === 'true';
+  const hasValue = input.value.trim() !== '';
+
+  if (!check.isValid && isTouched && hasValue) {
+    group.classList.add('auth-screen__form-group--invalid');
+    errorSpan.textContent = check.error;
+  } else {
+    group.classList.remove('auth-screen__form-group--invalid');
+    errorSpan.textContent = '';
+  }
+}
+
+function createToggleSection(isSignUp: boolean, onToggle: () => void) {
+  const toggleWrapper = document.createElement('div');
+  toggleWrapper.className = 'auth-screen__toggle';
+
+  const toggleText = document.createElement('span');
+  toggleText.textContent = isSignUp ? 'Already have an account? ' : "Don't have an account? ";
+
+  const toggleBtn = document.createElement('button');
+  toggleBtn.type = 'button';
+  toggleBtn.className = 'auth-screen__toggle-btn';
+  toggleBtn.textContent = isSignUp ? 'Log In' : 'Sign Up';
+
+  toggleBtn.addEventListener('click', onToggle);
+  toggleWrapper.append(toggleText, toggleBtn);
+
+  return toggleWrapper;
+}
+
+function setupFormValidation(
+  isSignUp: boolean,
+  emailField: ReturnType<typeof createInputGroup>,
+  passField: ReturnType<typeof createInputGroup>,
+  submitBtn: HTMLButtonElement,
+  usernameField: ReturnType<typeof createInputGroup> | null,
+) {
+  const validateForm = () => {
+    const emailCheck = validateEmail(emailField.input.value);
+    const passCheck = validatePassword(passField.input.value);
+
+    applyValidation(emailField, emailCheck);
+    applyValidation(passField, passCheck);
+
+    let isFormValid = emailCheck.isValid && passCheck.isValid;
+
+    if (isSignUp && usernameField) {
+      const nameCheck = validateUsername(usernameField.input.value);
+      applyValidation(usernameField, nameCheck);
+      isFormValid = isFormValid && nameCheck.isValid;
+    }
+
+    submitBtn.disabled = !isFormValid;
+  };
+
+  const debouncedValidate = debounce(validateForm, 300);
+
+  const markAsTouchedAndValidate = (inputElement: HTMLInputElement) => {
+    inputElement.dataset.touched = 'true';
+    debouncedValidate();
+  };
+
+  ['input', 'change'].forEach((evt) => {
+    emailField.input.addEventListener(evt, () => markAsTouchedAndValidate(emailField.input));
+    passField.input.addEventListener(evt, () => markAsTouchedAndValidate(passField.input));
+    if (usernameField) {
+      usernameField.input.addEventListener(evt, () =>
+        markAsTouchedAndValidate(usernameField.input),
+      );
+    }
+  });
+
+  return validateForm;
 }
 
 export function renderAuthScreen(handlers: AuthScreenHandlers): HTMLElement {
@@ -158,122 +279,4 @@ export function renderAuthScreen(handlers: AuthScreenHandlers): HTMLElement {
 
   renderCardContent();
   return screen;
-}
-
-function renderAvatarPicker(
-  avatars: string[],
-  selectedAvatar: string,
-  onSelect: (avatar: string) => void,
-): HTMLFieldSetElement {
-  const avatarPicker = document.createElement('fieldset');
-  avatarPicker.className = 'auth-screen__avatar-picker';
-
-  const legend = document.createElement('legend');
-  legend.className = 'auth-screen__avatar-title';
-  legend.textContent = 'Choose your avatar:';
-  avatarPicker.appendChild(legend);
-
-  const avatarlist = document.createElement('div');
-  avatarlist.className = 'auth-screen__avatar-list';
-
-  const avatarButtons: HTMLButtonElement[] = [];
-
-  avatars.forEach((src) => {
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = `auth-screen__avatar-btn ${selectedAvatar === src ? 'is-selected' : ''}`;
-
-    const img = document.createElement('img');
-    img.src = src;
-    img.alt = 'Avatar';
-    img.className = 'auth-screen__avatar-img';
-
-    btn.appendChild(img);
-    btn.addEventListener('click', () => {
-      onSelect(src);
-      avatarButtons.forEach((b) => b.classList.remove('is-selected'));
-      btn.classList.add('is-selected');
-    });
-
-    avatarButtons.push(btn);
-    avatarlist.appendChild(btn);
-  });
-  avatarPicker.appendChild(avatarlist);
-  return avatarPicker;
-}
-
-function applyValidation(field: ReturnType<typeof createInputGroup>, check: ValidationResult) {
-  const isTouched = field.input.dataset.touched === 'true';
-  const hasValue = field.input.value.trim() !== '';
-
-  if (!check.isValid && isTouched && hasValue) {
-    field.group.classList.add('auth-screen__form-group--invalid');
-    field.errorSpan.textContent = check.error;
-  } else {
-    field.group.classList.remove('auth-screen__form-group--invalid');
-    field.errorSpan.textContent = '';
-  }
-}
-
-function createToggleSection(isSignUp: boolean, onToggle: () => void) {
-  const toggleWrapper = document.createElement('div');
-  toggleWrapper.className = 'auth-screen__toggle';
-
-  const toggleText = document.createElement('span');
-  toggleText.textContent = isSignUp ? 'Already have an account? ' : "Don't have an account? ";
-
-  const toggleBtn = document.createElement('button');
-  toggleBtn.type = 'button';
-  toggleBtn.className = 'auth-screen__toggle-btn';
-  toggleBtn.textContent = isSignUp ? 'Log In' : 'Sign Up';
-
-  toggleBtn.addEventListener('click', onToggle);
-  toggleWrapper.append(toggleText, toggleBtn);
-
-  return toggleWrapper;
-}
-
-function setupFormValidation(
-  isSignUp: boolean,
-  emailField: ReturnType<typeof createInputGroup>,
-  passField: ReturnType<typeof createInputGroup>,
-  submitBtn: HTMLButtonElement,
-  usernameField: ReturnType<typeof createInputGroup> | null,
-) {
-  const validateForm = () => {
-    const emailCheck = validateEmail(emailField.input.value);
-    const passCheck = validatePassword(passField.input.value);
-
-    applyValidation(emailField, emailCheck);
-    applyValidation(passField, passCheck);
-
-    let isFormValid = emailCheck.isValid && passCheck.isValid;
-
-    if (isSignUp && usernameField) {
-      const nameCheck = validateUsername(usernameField.input.value);
-      applyValidation(usernameField, nameCheck);
-      isFormValid = isFormValid && nameCheck.isValid;
-    }
-
-    submitBtn.disabled = !isFormValid;
-  };
-
-  const debouncedValidate = debounce(validateForm, 300);
-
-  const markAsTouchedAndValidate = (inputElement: HTMLInputElement) => {
-    inputElement.dataset.touched = 'true';
-    debouncedValidate();
-  };
-
-  ['input', 'change'].forEach((evt) => {
-    emailField.input.addEventListener(evt, () => markAsTouchedAndValidate(emailField.input));
-    passField.input.addEventListener(evt, () => markAsTouchedAndValidate(passField.input));
-    if (usernameField) {
-      usernameField.input.addEventListener(evt, () =>
-        markAsTouchedAndValidate(usernameField.input),
-      );
-    }
-  });
-
-  return validateForm;
 }

--- a/app/src/utils/debounce.ts
+++ b/app/src/utils/debounce.ts
@@ -1,4 +1,4 @@
-export function debounce<T extends (...args: any[]) => void>(
+export default function debounce<T extends (...args: any[]) => void>(
   func: T,
   delay: number,
 ): (...args: Parameters<T>) => void {


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #64

---

# 📌 Type of Change

- [ ] Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Infrastructure
- [ ] Documentation
- [ ] Performance Improvement

---

# 📝 Description

This PR resolves **Issue #64** by implementing robust Route Guards and fixing the Auth Initialization flow. It also includes a refactoring step to centralize the Global Loader logic.

**What was added/changed:**
- **Route Guards (Whitelist Approach):** Introduced a strict whitelist (`publicRoutes`) in `handleRouterChange`. Unauthenticated users attempting to access protected routes (or random 404 URLs) are now correctly intercepted and redirected to the `auth` screen.
- **Smart Auth Watcher:** Rewrote `watchAuth` to correctly sync `INITIAL_SESSION` and `SIGNED_IN` events with the global Store. This explicitly fixes the "F5 Refresh Bug" where users were kicked out of their current game state upon reloading.
- **Cleaned Initialization:** Completely removed the redundant `initAuth` function to prevent race conditions during app startup.
- **Smart Start Screen:** The `start` screen is now accessible to everyone. The "START" button dynamically routes to either `dashboard` (if logged in) or `auth` (if not).
- **Global Loader Refactor:** Moved `Loader.show()` and `Loader.hide()` out of UI components (`authScreen.ts`) and into the main controller (`main.ts`). The loader now also protects the `onSignOut` flow.

---

# 🧠 Technical Details

- **Files modified:** `src/main.ts`, `src/services/auth.ts`, `src/ui/screens/authScreen.ts`
- **State/Event flow:** - `auth.ts` now properly passes `event` and `session` payload through the `onAuthStateChange` callback.
  - `main.ts` uses `await getSession()` synchronously before applying route changes to guarantee state accuracy.

---

# 🧪 How to Test in progress

1. **Test F5 Bug:** Log in, navigate to `#/day/1`, and hit F5. You should remain on `#/day/1` without being redirected to the dashboard.
2. **Test Route Guards:** Open an Incognito window and try to manually navigate to `#/dashboard` or `#/day/999`. You should be instantly redirected to `#/auth`.
3. **Test Start Screen:** Log in, then manually navigate to `#/start`. Click the "START" button. You should be taken directly to the dashboard without needing to log in again.
4. **Test Global Loader:** Click "Logout" and observe the global loader overlay preventing further interactions until the server responds.

---

# ⚠️ Breaking Changes

- [x] No breaking changes

---

# 📋 Checklist

- [x] Code compiles
- [x] Lint passes
- [x] TypeScript passes
- [x] No console errors
- [x] Follows project structure
- [x] Linked to correct Issue
- [x] Tested manually
